### PR TITLE
Enable dependabot: Go and Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+    time: "02:00"
+    timezone: UTC
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "02:00"
+    timezone: UTC
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This PR enables [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) on this repository.

It's configured to update Go files and Github Actions.

Signed-off-by: Maicon Costa <maiconscosta@gmail.com>