### PR TITLE
Update CI to test on Go 1.17 and 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: Tests
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
 
     runs-on: ubuntu-latest
 
@@ -20,7 +26,7 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-  
+
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...


### PR DESCRIPTION
We use Go 1.18, so best to test on that... Leaving 1.17 too in case anyone else still needs 1.17...

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>