### PR TITLE
Drop Go 1.17, add 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.17', '1.18' ]
+        go: [ '1.18', '1.19' ]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Go 1.19 is out, time to drop 1.17 support

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>