### PR TITLE
ci(fix): tweak allow-list for conventional commit types

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: feat,fix,docs,deps,chore,build,ci


### PR DESCRIPTION
Tweaking the allow-list, especially to allow a separate `deps` type, so we can hide `build` entries from the changelog without also losing visibility on dependency updates.