### PR TITLE
ci(fix): migrate release-please to GATB

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,19 +14,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Get App Credentials from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # 1.2.0
-        id: get-secrets
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=release-app:client-id
-            GITHUB_APP_PRIVATE_KEY=release-app:private-key
-          export_env: false
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      - name: Get GitHub App token
         id: app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          github_app: hosted-grafana-release-trigger
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replaces the legacy `get-vault-secrets` + `actions/create-github-app-token` pattern with the GATB-backed `grafana/shared-workflows/actions/create-github-app-token` shared action
- The GitHub App private key no longer leaves Vault — only a short-lived installation token is returned to the workflow

## Test plan
- [ ] Verify release-please workflow runs successfully after merge